### PR TITLE
fix: obsidian notificaion desc fix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "glasp",
 	"name": "Glasp",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"minAppVersion": "1.7.7",
 	"description": "Import your Glasp highlights and notes into your vault.",
 	"author": "Glasp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "glasp-obsidian-plugin",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "glasp-obsidian-plugin",
-			"version": "0.1.4",
+			"version": "0.1.5",
 			"license": "MIT",
 			"dependencies": {
 				"handlebars": "4.7.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "glasp-obsidian-plugin",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "Obsidian plugin to import your Glasp Highlights into your vault.",
 	"main": "main.js",
 	"scripts": {

--- a/src/core/import-highlights/import-highlights.ts
+++ b/src/core/import-highlights/import-highlights.ts
@@ -29,7 +29,7 @@ export class ImportHighlights {
 	}
 
 	async run({ accessToken, folder }: { accessToken: string; folder: string }) {
-		new ObsidianNotice("Updating highlights from Glasp");
+		new ObsidianNotice("Updating highlights");
 
 		try {
 			const userHighlights: UserHighlight[] = [];


### PR DESCRIPTION
# Changes
* Fixed: Removed `from Glasp` from [new ObsidianNotice("Updating highlights from Glasp");](https://github.com/glasp-co/obsidian-glasp-plugin/blob/8ba0aa849f7479103c2c3bbc71b7681f138ac6b8/src/core/import-highlights/import-highlights.ts#L32)

