### PR TITLE
Escape titles of highlights that contain specific characters

### DIFF
--- a/src/obsidian-api/obsidian-app.ts
+++ b/src/obsidian-api/obsidian-app.ts
@@ -32,7 +32,7 @@ export class ObsidianApp {
 		const templateDelegator = compile(template, { noEscape: true });
 		const targetData = templateDelegator(data);
 
-		const path = `${folder}/${filename}.md`;
+		const path = `${folder}/${this.escapeFilename(filename)}.md`;
 
 		const result = await this.getVault().create(path, targetData);
 		return result;
@@ -67,5 +67,17 @@ export class ObsidianApp {
 
 	private getVault(): Vault {
 		return this.getApp().vault;
+	}
+
+	private escapeFilename(filename: string): string {
+		const SPECIAL_CHARS = ["[", "]", "|", ":", "\\", "/", "#", "^"];
+
+		const escapedChars = SPECIAL_CHARS.map((char) => {
+			return char.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		});
+
+		const regex = new RegExp(`[${escapedChars.join("")}]`, "g");
+
+		return filename.replace(regex, "");
 	}
 }


### PR DESCRIPTION
## Description
* #14 
* In Obsidian, the following characters cannot be included in filenames, therefore they need to be escaped.
  * `[`
  * `]`
  * `|`
  * `:`
  * `\`
  * `/`
  * `#`
  * `^`