### PR TITLE
docs: update README for v0.3.0 (Summaries, Bookmarks, Bases views)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/glasp-co/obsidian-glasp-plugin/actions/workflows/ci.yml/badge.svg)
 
-Import your [**Glasp**](https://glasp.co/) highlights and notes — from the web **and from Kindle** — directly into your [Obsidian](https://obsidian.md/) vault, and keep them in sync automatically.
+Import your [**Glasp**](https://glasp.co/) highlights, notes, **summaries**, and **bookmarks** — from the web **and from Kindle** — directly into your [Obsidian](https://obsidian.md/) vault, and keep them in sync automatically.
 
 > [Glasp](https://glasp.co/) is a social web highlighter that lets you highlight and take notes on the web, PDFs, YouTube, and Kindle, then own and export everything you collect. This plugin brings that knowledge into Obsidian as Markdown notes you fully control.
 
@@ -11,11 +11,18 @@ Import your [**Glasp**](https://glasp.co/) highlights and notes — from the web
 ## ✨ Features
 
 - 📥 **Import web highlights & notes** from Glasp into a folder of your choice.
-- 📚 **Import Kindle highlights & notes** ([new in v0.2.0](https://glasp.co/)) into a **separate** folder, so book highlights stay out of your web notes.
+- 📚 **Import Kindle highlights & notes** into a **separate** folder, so book highlights stay out of your web notes.
+- 📝 **Import summaries** — your Glasp AI page/video summaries as notes, optionally embedding the full article/PDF text.
+- 🔖 **Import bookmarks** — every page you've saved, as lightweight, metadata-rich notes.
+- 🗂️ **Database views (Obsidian Bases)** — each source gets an auto-generated `.base` view collected in a dedicated **`Glasp Bases`** folder, so you can browse everything as a sortable **Table** or a **Cards** gallery with thumbnails. _(Requires Obsidian 1.9+.)_
 - 🔁 **Automatic background sync** — every hour, every day, or once a week.
-- ➕ **Incremental & non-destructive** — only new/updated highlights are fetched, and existing notes are matched by source URL and updated in place (no duplicates).
-- 🎨 **Customizable templates** — define your own Markdown layout and frontmatter for web and Kindle notes, or use the sensible defaults.
+- ➕ **Incremental & non-destructive** — only new/updated items are fetched, and existing notes are matched by source URL and updated in place (no duplicates).
+- 🎨 **Customizable templates** — define your own Markdown layout and frontmatter for every source, or use the sensible defaults.
 - 📱 **Desktop & mobile** — works anywhere Obsidian runs.
+
+## ✅ Requirements
+
+- **Obsidian 1.9.0 or later** (the auto-generated database views use the built-in **Bases** core plugin). On older versions, use plugin **v0.2.x**.
 
 ## 📦 Installation
 
@@ -35,9 +42,12 @@ Import your [**Glasp**](https://glasp.co/) highlights and notes — from the web
 1. **Get your access token** from your Glasp account: **https://glasp.co/settings/access_token**
    - 💡 If the link opens *inside* Obsidian and you can’t sign in, use the **copy button** next to the token field and paste the URL into your default browser (Chrome, Safari, etc.).
 2. In **Settings → Glasp**, paste the **Access token**.
-3. Choose an **output folder** for web highlights and/or an **output folder** for Kindle highlights.
-   - Leaving a folder unset simply skips that source — enable web, Kindle, or both.
-4. Pick an **update frequency**. Your highlights are imported on startup and then on that schedule. You can also trigger an import any time via the ribbon icon or the command palette (**“Glasp: Import highlights”**).
+3. Choose an **output folder** for each source you want — web highlights, Kindle highlights, summaries, and/or bookmarks.
+   - Leaving a folder unset simply skips that source, so you can enable any combination.
+   - Tip: give each source its own folder to keep them tidy.
+4. Pick an **update frequency**. Your data is imported on startup and then on that schedule. You can also trigger an import any time via the ribbon icon or the command palette (**“Glasp: Import highlights”**).
+
+Once a source has imported, a matching database view appears in the **`Glasp Bases`** folder — open it and switch between **Table** and **Cards** at the top.
 
 ## ⚙️ Settings
 
@@ -46,18 +56,40 @@ Import your [**Glasp**](https://glasp.co/) highlights and notes — from the web
 | **Access token** | Your Glasp API token. Stored locally in your vault and sent only to `api.glasp.co`. |
 | **Web highlights output folder** | Where web highlight notes are saved. Unset = skip web import. |
 | **Kindle highlights output folder** | Where Kindle highlight notes are saved. Unset = skip Kindle import. |
-| **Web / Kindle highlights template** | Custom note layout (see below). Empty = default template. |
-| **Update frequency** | How often highlights are synced automatically (hourly / daily / weekly). |
+| **Summaries output folder** | Where summary notes are saved. Unset = skip summary import. |
+| **Include full page content in summaries** | Also embed the full article/PDF text in each summary note. Slower (one extra request per summary) and makes notes larger. |
+| **Bookmarks output folder** | Where bookmark notes are saved. Unset = skip bookmark import. |
+| **Update frequency** | How often your data is synced automatically (hourly / daily / weekly). |
+| **Templates (Advanced)** | Custom note layout for each source (see below). Empty = default template. |
+
+## 🗂️ Database views (Bases)
+
+For every enabled source, the plugin creates a [Bases](https://help.obsidian.md/bases) view in a top-level **`Glasp Bases`** folder — for example `Glasp Bookmarks.base` and `Glasp Summaries.base`. Each view is a live database over that source's notes, so your imports read like a table instead of a long file list:
+
+- **Table** view for sorting and scanning by domain, date, tags, etc.
+- **Cards** view with thumbnail covers for a visual gallery.
+
+The views are created once and are **not** re-created if you delete them, so you're free to customize or remove them. A view's folder filter is updated automatically if you later change that source's output folder.
+
+> Bases is a core plugin included with Obsidian 1.9+. Enable it under **Settings → Core plugins → Bases** if it isn't already.
 
 ## 🎨 Customizing the template
 
 You can fully control how each note looks using [Handlebars](https://handlebarsjs.com/) placeholders. Leave a template empty to use the default.
 
 **Web highlights** — available variables:
-`{{url}}` · `{{glasp_url}}` · `{{tags}}` · `{{updated_at}}` · `{{content}}`
+`{{url}}` · `{{glasp_url}}` · `{{thumbnail_url}}` · `{{tags}}` · `{{updated_at}}` · `{{content}}`
 
 **Kindle highlights** — available variables:
-`{{url}}` · `{{glasp_url}}` · `{{author}}` · `{{tags}}` · `{{updated_at}}` · `{{content}}`
+`{{url}}` · `{{glasp_url}}` · `{{author}}` · `{{thumbnail_url}}` · `{{tags}}` · `{{updated_at}}` · `{{content}}`
+
+**Summaries** — available variables:
+`{{url}}` · `{{title}}` · `{{domain}}` · `{{thumbnail_url}}` · `{{created_at}}` · `{{updated_at}}` · `{{summary}}` · `{{content}}`
+
+**Bookmarks** — available variables:
+`{{url}}` · `{{title}}` · `{{domain}}` · `{{category}}` · `{{description}}` · `{{thumbnail_url}}` · `{{created_at}}` · `{{updated_at}}` · `{{title_text}}` · `{{url_text}}`
+
+> ℹ️ Frontmatter values (e.g. `{{title}}`, `{{domain}}`) are emitted already quoted so they can't break the note's Properties — keep them on their own line. The `_text` variants are unquoted, for use in the note body (e.g. a Markdown link). Keeping the `URL` property in your template is what lets the plugin match and update existing notes instead of duplicating them.
 
 <details>
 <summary>Default web template</summary>
@@ -66,6 +98,7 @@ You can fully control how each note looks using [Handlebars](https://handlebarsj
 ---
 URL: {{url}}
 Glasp URL: {{glasp_url}}
+Thumbnail: {{thumbnail_url}}
 Tags: [{{tags}}]
 Last updated: {{updated_at}}
 ---
@@ -81,6 +114,7 @@ Last updated: {{updated_at}}
 URL: {{url}}
 Glasp URL: {{glasp_url}}
 Author: {{author}}
+Thumbnail: {{thumbnail_url}}
 Tags: [{{tags}}]
 Last updated: {{updated_at}}
 ---
@@ -88,10 +122,51 @@ Last updated: {{updated_at}}
 ```
 </details>
 
+<details>
+<summary>Default summary template</summary>
+
+```handlebars
+---
+Glasp: summary
+URL: {{url}}
+Title: {{title}}
+Domain: {{domain}}
+Thumbnail: {{thumbnail_url}}
+Created: {{created_at}}
+Updated: {{updated_at}}
+---
+
+## Summary
+
+{{summary}}
+{{content}}
+```
+</details>
+
+<details>
+<summary>Default bookmark template</summary>
+
+```handlebars
+---
+Glasp: bookmark
+URL: {{url}}
+Title: {{title}}
+Domain: {{domain}}
+Category: {{category}}
+Description: {{description}}
+Thumbnail: {{thumbnail_url}}
+Created: {{created_at}}
+Updated: {{updated_at}}
+---
+
+[{{title_text}}](<{{url_text}}>)
+```
+</details>
+
 ## 🔒 Privacy & security
 
 - Your access token is stored **locally** in your vault (`.obsidian/plugins/glasp/data.json`) and is used **only** to call the official Glasp API at `https://api.glasp.co`.
-- The plugin has **read-only** access to your own highlights. It never sends your notes anywhere.
+- The plugin has **read-only** access to your own content. It never sends your notes anywhere.
 - ⚠️ If you sync or share your vault, be aware that `data.json` contains your token — treat it like a password.
 
 ## 🛠️ Development


### PR DESCRIPTION
Documentation-only update to match **v0.3.0** (which added Summaries & Bookmarks import and per-source Obsidian **Bases** database views).

### Changes
- **Features**: added Summaries, Bookmarks, and the `Glasp Bases` database views (Table/Cards + thumbnails).
- **Requirements**: noted **Obsidian 1.9.0+** (Bases); older Obsidian stays on v0.2.x.
- **Getting started / Settings**: documented the summaries & bookmarks output folders and the **"Include full page content in summaries"** toggle.
- **New section**: "Database views (Bases)" explaining the `Glasp Bases` folder and Table/Cards.
- **Templates**: added the summary & bookmark template variables and default templates; added `{{thumbnail_url}}` to web/Kindle; noted that frontmatter values are auto-quoted and that keeping `URL` enables de-duplication.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)